### PR TITLE
fix for  Molecule.get method

### DIFF
--- a/CGRdb/database/molecule.py
+++ b/CGRdb/database/molecule.py
@@ -168,7 +168,7 @@ class Molecule(Entity):
         elif not isinstance(mol, MoleculeContainer):
             raise ValueError("CGRtools.MoleculeContainer should be provided")
         try:
-            m = MoleculeStructure.get(signature=mol.pack()).molecule
+            m = MoleculeStructure.get(signature=bytes(mol)).molecule
         except AttributeError:
             m = None
         return m


### PR DESCRIPTION
we use method bytes(mol) for signatures instead of mol.pack() as mol.pack() gives not unique hashes